### PR TITLE
Remove object reference to allow relationship field assign

### DIFF
--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -91,8 +91,10 @@ const ChartContainer = forwardRef(
           attachRel(item, flags === "00" ? flags : "1" + (data.length > 1 ? 1 : 0));
         });
       }
-      data.relationship =
-        flags + (data.children && data.children.length > 0 ? 1 : 0);
+
+      data = Object.assign({}, data)
+      data.relationship = flags + (data.children && data.children.length > 0 ? 1 : 0);
+
       if (data.children) {
         data.children.forEach(function (item) {
           attachRel(item, "1" + (data.children.length > 1 ? 1 : 0));


### PR DESCRIPTION
This fixes this bug that crashes page:
![image](https://user-images.githubusercontent.com/38140593/131398729-85c9d63d-73c1-4bd7-bf8c-5f1a99fb3c6d.png)

I think it's because some data is coming from the `store` therefore the data is not able to directly edited ( but, other data was able to be updated, so maybe not that )

The code I added:
```javascript
      data = Object.assign({}, data)
```

Removes the object reference, allowing `data.relationship = ` to be set without throwing any errors
